### PR TITLE
Wire new DB scorer to context builder

### DIFF
--- a/ai_memory/context_builder.py
+++ b/ai_memory/context_builder.py
@@ -1,48 +1,47 @@
-from typing import Dict, List
-
+from typing import List, Dict
 
 class ContextBuilder:
-    def build_layers(
-        self, scored_memories: List[Dict], token_budget: int
-    ) -> str:
+    def build_layers(self, scored_memories: List[Dict], token_budget: int) -> str:
         memories_by_value = sorted(
             scored_memories,
             key=lambda x: x["score"] / max(x["token_cost"], 1),
             reverse=True,
         )
 
-        context_layers = {
-            "essential": [],
-            "relevant": [],
-            "supplemental": [],
-        }
-
+        layers = {"essential": [], "relevant": [], "supplemental": []}
         tokens_used = 0
-        essential_budget = token_budget * 0.2
+
+        # 1) essential (20 %)
         for mem in memories_by_value:
-            if tokens_used + mem["token_cost"] <= essential_budget:
-                context_layers["essential"].append(mem)
+            if mem["token_cost"] + tokens_used > token_budget * 0.2:
+                continue
+            if mem.get("type") in ("core_identity", "active_project_state"):
+                layers["essential"].append(mem)
                 tokens_used += mem["token_cost"]
 
-        relevant_budget = token_budget * 0.6
+        # 2) relevant (60 %)
         for mem in memories_by_value:
-            if mem not in context_layers["essential"] and mem["score"] > 15:
-                if tokens_used + mem["token_cost"] <= relevant_budget:
-                    context_layers["relevant"].append(mem)
-                    tokens_used += mem["token_cost"]
+            if mem in layers["essential"]:
+                continue
+            if mem["score"] > 15 and mem["token_cost"] + tokens_used <= token_budget * 0.8:
+                layers["relevant"].append(mem)
+                tokens_used += mem["token_cost"]
 
+        # 3) supplemental (fill → 95 %)
         for mem in memories_by_value:
-            if mem not in context_layers["essential"] + context_layers["relevant"]:
-                if tokens_used + mem["token_cost"] <= token_budget * 0.95:
-                    context_layers["supplemental"].append(mem)
-                    tokens_used += mem["token_cost"]
+            if mem in layers["essential"] or mem in layers["relevant"]:
+                continue
+            if mem["token_cost"] + tokens_used <= token_budget * 0.95:
+                layers["supplemental"].append(mem)
+                tokens_used += mem["token_cost"]
 
-        return self._format_context(context_layers, tokens_used)
+        return self._format(layers)
 
-    def _format_context(self, layers: Dict[str, List[Dict]], tokens_used: int) -> str:
-        formatted = [f"TOTAL TOKENS USED: {tokens_used}"]
-        for layer in ["essential", "relevant", "supplemental"]:
-            formatted.append(f"=== {layer.upper()} ===")
-            for mem in layers[layer]:
-                formatted.append(f"[{mem['mem_id']}] {mem['content']}")
-        return "\n".join(formatted)
+    @staticmethod
+    def _format(layers: Dict[str, List[Dict]]) -> str:
+        ordered = (
+            [m["content"] for m in layers["essential"]]
+            + [m["content"] for m in layers["relevant"]]
+            + [m["content"] for m in layers["supplemental"]]
+        )
+        return "\n".join(ordered)


### PR DESCRIPTION
## Summary
- update `ContextBuilder` to work with data from the new `RelevanceEngine`
- assemble layers using `mem["content"]`

## Testing
- `python - <<'PY'
from ai_memory.memory_optimizer import MemoryOptimizer
opt = MemoryOptimizer()
ctx = opt.build_optimal_context({"name": "gpt-4", "max_tokens": 8000}, current_task="debug piper TTS on android")
print(ctx[:400] or "[empty context]")
PY`
- `python - <<'PY'
from ai_memory.memory_optimizer import MemoryOptimizer
print("Context length:", len(MemoryOptimizer().build_optimal_context({"name": "gpt-4", "max_tokens": 8000}, current_task="SMTP timeout diagnosis")))
PY`


------
https://chatgpt.com/codex/tasks/task_e_687705ce2ae4833284d0ade34d74b38a