### PR TITLE
Add conversation session layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ The code in `ai_memory/` includes:
   types without external dependencies.
 * Utilities for importing existing conversation logs via JSON with validation
   and batch support.
+* 2025-07-16 → switched to SQLite backend, added conversation session layer.

--- a/ai_memory/conversation_manager.py
+++ b/ai_memory/conversation_manager.py
@@ -1,0 +1,14 @@
+from ai_memory.conversation_session import ConversationSession
+
+class ConversationManager:
+    """Keeps a registry of active sessions."""
+
+    def __init__(self):
+        self.sessions = {}
+
+    def get(self, session_id: str | None) -> ConversationSession:
+        if session_id and session_id in self.sessions:
+            return self.sessions[session_id]
+        sess = ConversationSession()
+        self.sessions[sess.session_id] = sess
+        return sess

--- a/ai_memory/conversation_session.py
+++ b/ai_memory/conversation_session.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import uuid, time
+from ai_memory.memory_optimizer import MemoryOptimizer
+
+class ConversationSession:
+    def __init__(self, title: str | None = None):
+        self.session_id = str(uuid.uuid4())
+        self.title = title or "untitled"
+        self.start_ts = time.time()
+        self.optimizer = MemoryOptimizer()
+
+    def build_context(self, user_prompt: str, model="gpt-4", limit=8000):
+        return self.optimizer.build_optimal_context(
+            {"name": model, "max_tokens": limit},
+            current_task=user_prompt,
+            conversation_id=self.session_id,
+        )

--- a/ai_memory/token_counter.py
+++ b/ai_memory/token_counter.py
@@ -1,12 +1,4 @@
-# smarter ~85% accurate estimator, zero deps
-import re
-
-URL = re.compile(r"https?://\S+")
-PUNCT = re.compile(r"[^\w\s]")
-
-def rough_token_len(text: str) -> int:
-    base = len(text) // 4
-    return base + text.count("\n") + len(URL.findall(text)) + len(PUNCT.findall(text)) // 10
+from ai_memory.memory_db import rough_token_len
 
 class TokenCounter:
     @staticmethod


### PR DESCRIPTION
## Summary
- rename legacy package and keep compat stub
- add `ConversationSession` and `ConversationManager` wrappers
- simplify `TokenCounter`
- document new SQLite backend and sessions layer
- improve JSON importer robustness and allow skipping import

## Testing
- `python - <<'PY'
from ai_memory.conversation_manager import ConversationManager
cm = ConversationManager()
sess = cm.get(None)
ctx = sess.build_context("diagnose SMTP 421 timeout")
assert isinstance(ctx, str)
print("Context tokens:", len(ctx.split()), "\u2713")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68770b5a62a48332aae413548360fa91