### PR TITLE
Add setup script and package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ The code in `ai_memory/` includes:
 * Utilities for importing existing conversation logs via JSON with validation
   and batch support.
 * 2025-07-16 → switched to SQLite backend, added conversation session layer.
+* A Flask-based API server for adding memories, building context, and exporting
+  data (`python -m ai_memory.api`).
+* Built-in model configuration with context budgets via `model_config.py`.
+* Convenience setup script `setup_memory_system.sh` to install dependencies
+  and provide usage examples.

--- a/ai_memory/__init__.py
+++ b/ai_memory/__init__.py
@@ -1,0 +1,13 @@
+"""Convenience imports for ai_memory package."""
+
+from . import cli  # Ensure CLI commands are registered
+from .api import app
+from .model_config import get_model_budget
+from .dream_lord import DreamLord
+
+__all__ = [
+    "cli",
+    "app",
+    "get_model_budget",
+    "DreamLord",
+]

--- a/ai_memory/api.py
+++ b/ai_memory/api.py
@@ -1,0 +1,127 @@
+from flask import Flask, request, jsonify, Response
+from .conversation_manager import ConversationManager
+from .conversation_session import ConversationSession
+from .memory_store import MemoryStore
+from .model_config import get_model_budget
+
+app = Flask(__name__)
+conv_manager = ConversationManager()
+
+
+@app.route('/health', methods=['GET'])
+def health():
+    """Health check endpoint."""
+    return jsonify({"status": "ok"})
+
+
+@app.route('/memory', methods=['POST'])
+def add_memory():
+    """Add a new memory via JSON input."""
+    try:
+        data = request.get_json(force=True)
+    except Exception as e:
+        return jsonify({"error": f"Invalid JSON: {e}"}), 400
+    if not data or "content" not in data:
+        return jsonify({"error": "Content is required."}), 400
+    content = data.get("content", "")
+    importance = data.get("importance", 1.0)
+    conv_id = data.get("conversation_id", None)
+    try:
+        importance = float(importance)
+    except Exception:
+        return jsonify({"error": "Importance must be a number."}), 400
+    try:
+        if conv_id:
+            session = conv_manager.sessions.get(conv_id)
+            if not session:
+                session = ConversationSession()
+                session.session_id = conv_id
+                conv_manager.sessions[conv_id] = session
+            cur = session.optimizer.store.conn.cursor()
+            ts = session.start_ts
+            from datetime import datetime
+
+            ts_iso = datetime.fromtimestamp(ts).astimezone().isoformat()
+            cur.execute(
+                "INSERT OR IGNORE INTO conversations (conv_id, user_id, title, started_at, updated_at) VALUES (?,?,?,?,?)",
+                (conv_id, "default", session.title, ts_iso, ts_iso),
+            )
+            cur.execute(
+                "UPDATE conversations SET updated_at=? WHERE conv_id=?",
+                (datetime.now().astimezone().isoformat(), conv_id),
+            )
+            mem_id = session.optimizer.store.add(
+                content, conv_id=conv_id, importance=importance
+            )
+        else:
+            store = MemoryStore()
+            mem_id = store.add(content, conv_id=None, importance=importance)
+            store.conn.close()
+        return jsonify({"status": "success", "mem_id": mem_id}), 200
+    except Exception as e:
+        return jsonify({"error": f"Failed to add memory: {e}"}), 500
+
+
+@app.route('/context', methods=['POST'])
+def build_context():
+    """Build optimized context via JSON input."""
+    try:
+        data = request.get_json(force=True)
+    except Exception as e:
+        return jsonify({"error": f"Invalid JSON: {e}"}), 400
+    if not data or "query" not in data:
+        return jsonify({"error": "Query is required."}), 400
+    query = data.get("query", "")
+    model = data.get("model", "gpt-4")
+    token_limit = data.get("token_limit", None)
+    conv_id = data.get("conversation_id", None)
+    try:
+        budget = get_model_budget(model, token_limit)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+    try:
+        if conv_id:
+            session = conv_manager.sessions.get(conv_id)
+            if not session:
+                session = ConversationSession()
+                session.session_id = conv_id
+                conv_manager.sessions[conv_id] = session
+            context_str = session.build_context(query, model=model, limit=budget)
+        else:
+            from .memory_optimizer import MemoryOptimizer
+
+            memopt = MemoryOptimizer()
+            context_str = memopt.build_optimal_context(
+                {"name": model, "max_tokens": budget}, current_task=query
+            )
+        return jsonify({"context": context_str}), 200
+    except Exception as e:
+        return jsonify({"error": f"Failed to build context: {e}"}), 500
+
+
+@app.route('/export/<fmt>', methods=['GET'])
+def export_memories(fmt):
+    """Export memories in specified format (json or markdown)."""
+    fmt = fmt.lower()
+    if fmt not in ("json", "markdown"):
+        return jsonify({"error": "Format not supported."}), 400
+    try:
+        store = MemoryStore()
+        data = store.get_all()
+        store.conn.close()
+        if fmt == "json":
+            return jsonify(data), 200
+        elif fmt == "markdown":
+            lines = []
+            for mem in data:
+                content = mem.get("content", "")
+                content_line = content.replace("\n", " ")
+                lines.append(f"- {content_line}")
+            md_text = "\n".join(lines)
+            return Response(md_text, mimetype="text/markdown")
+    except Exception as e:
+        return jsonify({"error": f"Failed to export memories: {e}"}), 500
+
+
+if __name__ == "__main__":
+    app.run(host="localhost", port=5678)

--- a/ai_memory/dream_lord.py
+++ b/ai_memory/dream_lord.py
@@ -1,0 +1,10 @@
+class DreamLord:
+    """Stub class for Dream Lord integration."""
+
+    def __init__(self, endpoint: str = "http://localhost:9999") -> None:
+        self.endpoint = endpoint
+
+    def send(self, prompt: str) -> str:
+        """Send a prompt to Dream Lord and return the response (stub)."""
+        # In a real implementation this would perform an HTTP request.
+        return f"[dream-lord stub] {prompt}"

--- a/setup_memory_system.sh
+++ b/setup_memory_system.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Setup script for AI Memory system
+
+# 1. Install required Python packages
+echo "Installing required Python packages (click, flask)..."
+pip install click flask
+
+# 2. Create shell alias for convenience
+ALIAS_CMD="alias aimem='python -m ai_memory.cli'"
+if ! grep -qxF "$ALIAS_CMD" ~/.bashrc; then
+    echo "$ALIAS_CMD" >> ~/.bashrc
+    echo "Added 'aimem' alias to ~/.bashrc (reload your shell to use it)."
+else
+    echo "Alias 'aimem' already present in your shell config."
+fi
+
+# 3. Display usage examples for the CLI
+cat <<'USAGE'
+
+✅ Installation complete. Here are some usage examples:
+  aimem add "Sample memory content" -i 5.0 -c my_conversation
+  aimem list -n 5 --conversation-id my_conversation
+  aimem context "What do we know about sample content?" --model gpt-4
+  aimem export --output backup_memories.json
+
+To start the API server, run:
+  python -m ai_memory.api
+
+USAGE
+
+# 4. (Optional) Print a systemd service template for running API server
+cat <<'SYSTEMD'
+----- Below is a sample systemd service unit (for reference only) -----
+[Unit]
+Description=AI Memory API Service
+After=network.target
+
+[Service]
+ExecStart=$(which python) -m ai_memory.api
+WorkingDirectory=$(pwd)
+Restart=always
+User=$USER
+Environment=AI_MEMORY_ROOT=$HOME/ai_memory
+
+[Install]
+WantedBy=multi-user.target
+-----------------------------------------------------------------------
+(Note: Copy the above into a file like /etc/systemd/system/aimemory.service and adjust as needed.)
+SYSTEMD


### PR DESCRIPTION
## Summary
- expose CLI, API app and model budgeting in `__init__.py`
- add DreamLord stub for future integration
- add convenience `setup_memory_system.sh`
- document setup script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877bdb3f5008332b1a5f89ea3b6df8a