### PR TITLE
Fix circular import and add test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - run: pip install -r memory_optimizer/requirements.txt
+    - run: pip install pytest click flask
+    - run: pytest -q
+      working-directory: memory_optimizer

--- a/ai_memory/__init__.py
+++ b/ai_memory/__init__.py
@@ -1,12 +1,11 @@
 """Convenience imports for ai_memory package."""
 
-from . import cli  # Ensure CLI commands are registered
+# Import core modules without loading the CLI to avoid circular dependencies
 from .api import app
 from .model_config import get_model_budget
 from .dream_lord import DreamLord
 
 __all__ = [
-    "cli",
     "app",
     "get_model_budget",
     "DreamLord",

--- a/memory_optimizer/requirements.txt
+++ b/memory_optimizer/requirements.txt
@@ -1,0 +1,2 @@
+click
+flask

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import subprocess, json, os, sys, tempfile, time
+
+
+def _run(cmd):
+    result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_add_and_list():
+    _run("python -m ai_memory.cli add 'pytest memory' -i 4.2 -c test_session")
+    out = _run("python -m ai_memory.cli list -n 1 -c test_session")
+    assert 'pytest memory' in out
+
+
+def test_context():
+    ctx = _run("python -m ai_memory.cli context 'pytest memory' --conversation-id test_session")
+    assert 'pytest memory' in ctx


### PR DESCRIPTION
## Summary
- avoid circular import by dropping CLI in `ai_memory.__init__`
- add pytest CLI tests
- configure GitHub Actions CI workflow
- add requirements file for CI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6877c3ee6e4c8332b07d73094e7a5f69