### PR TITLE
Add FAISS index self-healing and factory option

### DIFF
--- a/ai_memory/cli.py
+++ b/ai_memory/cli.py
@@ -17,11 +17,12 @@ def cli():
 @click.argument("file", type=click.Path(exists=True))
 @click.option("--vector-index", required=True, help="Path to FAISS/SQLite index")
 @click.option("--model", default="llama3:70b-instruct-q4_K_M")
-def vectorize(file, vector_index, model):
+@click.option("--factory", default="Flat", help="faiss index_factory string")
+def vectorize(file, vector_index, model, factory):
     """Embed a file into the vector index."""
     from .vector_embedder import embed_file
 
-    embed_file(file, vector_index, model)
+    embed_file(file, vector_index, model, factory=factory)
     click.echo(f"\u2713 Embedded {file} into {vector_index}")
 
 @cli.command()

--- a/ai_memory/ingest/zip_watcher.py
+++ b/ai_memory/ingest/zip_watcher.py
@@ -33,6 +33,8 @@ def process_zip(zip_path: Path, dest_root: Path, index: str | None, model: str |
             str(log_file),
             "--vector-index",
             index,
+            "--factory",
+            "Flat",
             "--model",
             model,
         ]

--- a/ai_memory/vector_embedder.py
+++ b/ai_memory/vector_embedder.py
@@ -1,14 +1,68 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
+import os
+
+import numpy as np
+import faiss
+
+logger = logging.getLogger(__name__)
 
 
-def embed_file(file: str, index_path: str, model: str) -> None:
-    """Trivial stand-in for vector embedding logic."""
-    index = Path(index_path)
-    index.parent.mkdir(parents=True, exist_ok=True)
+_DIMS = 1
+
+
+def _embed(file: str) -> np.ndarray:
+    """Return a trivial embedding for the given file."""
     with open(file, "rb") as f:
-        data = f.read()
-    # In lieu of a real embedding we just record the file length
-    with open(index, "a", encoding="utf-8") as idx:
-        idx.write(f"{Path(file).name}:{len(data)}\n")
+        length = len(f.read())
+    vec = np.array([[float(length)]], dtype="float32")
+    faiss.normalize_L2(vec)
+    return vec
+
+
+def _create_index(factory: str | None) -> faiss.Index:
+    if factory:
+        return faiss.index_factory(_DIMS, factory)
+    return faiss.IndexFlatIP(_DIMS)
+
+
+def _load_index(path: Path, factory: str | None) -> faiss.Index:
+    if not path.exists():
+        return _create_index(factory)
+    try:
+        return faiss.read_index(str(path))
+    except Exception as e:  # faiss may raise IOError or RuntimeError
+        if "not recognized" in str(e):
+            logger.warning("Index read error: %s", e)
+            try:
+                os.rename(path, path.with_suffix(path.suffix + ".corrupt"))
+            except OSError:
+                pass
+            # rebuild with a simple IndexFlatIP for compatibility
+            return faiss.IndexFlatIP(_DIMS)
+        raise
+
+
+def embed_file(file: str, index_path: str, model: str, factory: str | None = None) -> None:
+    """Embed a file into a FAISS index."""
+    index_file = Path(index_path)
+    index_file.parent.mkdir(parents=True, exist_ok=True)
+    index = _load_index(index_file, factory)
+    vec = _embed(file)
+    if not index.is_trained and hasattr(index, "train"):
+        index.train(vec)
+    index.add(vec)
+    faiss.write_index(index, str(index_file))
+
+
+def recall(file: str, index_path: str) -> float:
+    """Return similarity score for the file against the index."""
+    index = faiss.read_index(str(index_path))
+    vec = _embed(file)
+    D, _ = index.search(vec, 1)
+    score = float(D[0][0])
+    if index.metric_type == faiss.METRIC_L2:
+        score = 1.0 - score
+    return score

--- a/memory_optimizer/requirements.txt
+++ b/memory_optimizer/requirements.txt
@@ -1,3 +1,4 @@
 click
 flask
 pytest
+faiss-cpu==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "flask>=2.0.0",
+        "faiss-cpu>=1.8.0",
     ],
     extras_require={"test": ["pytest"]},
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,8 @@ def test_vectorize(tmp_path):
     txt = tmp_path / "sample.txt"
     txt.write_text("hello")
     index = tmp_path / "vec.idx"
-    out = _run(f"python -m ai_memory.cli vectorize {txt} --vector-index {index}")
+    out = _run(
+        f"python -m ai_memory.cli vectorize {txt} --vector-index {index} --factory Flat"
+    )
     assert "Embedded" in out
     assert index.exists()

--- a/tests/test_vector_embedder.py
+++ b/tests/test_vector_embedder.py
@@ -1,0 +1,17 @@
+import os
+from ai_memory.vector_embedder import embed_file, recall
+
+
+def test_self_heal(tmp_path):
+    doc = tmp_path / "doc.txt"
+    doc.write_text("hello world")
+    idx = tmp_path / "vec.faiss"
+
+    embed_file(str(doc), str(idx), "dummy", factory="Flat")
+    assert recall(str(doc), str(idx)) > 0.99
+
+    # corrupt the index
+    idx.write_bytes(os.urandom(64))
+
+    embed_file(str(doc), str(idx), "dummy", factory="Flat")
+    assert recall(str(doc), str(idx)) > 0.99


### PR DESCRIPTION
## Summary
- switch vector embedder to use FAISS
- add factory option to `aimem vectorize` and ingestion pipeline
- rebuild corrupted indices automatically
- add regression test for self-healing vector index

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688128b76294833286b712d330fae4cd