### PR TITLE
Handle JSON embedding for vectorize

### DIFF
--- a/ai_memory.egg-info/PKG-INFO
+++ b/ai_memory.egg-info/PKG-INFO
@@ -1,12 +1,16 @@
 Metadata-Version: 2.4
 Name: ai-memory
-Version: 0.1.0
+Version: 0.1.1
 Summary: SQLite-backed memory optimization for LLMs
 Author: BlakeFelix
 Requires-Python: >=3.8
 Requires-Dist: click>=8.0.0
 Requires-Dist: flask>=2.0.0
+Requires-Dist: faiss-cpu>=1.8.0
+Provides-Extra: test
+Requires-Dist: pytest; extra == "test"
 Dynamic: author
+Dynamic: provides-extra
 Dynamic: requires-dist
 Dynamic: requires-python
 Dynamic: summary

--- a/ai_memory/cli.py
+++ b/ai_memory/cli.py
@@ -18,11 +18,17 @@ def cli():
 @click.option("--vector-index", required=True, help="Path to FAISS/SQLite index")
 @click.option("--model", default="llama3:70b-instruct-q4_K_M")
 @click.option("--factory", default="Flat", help="faiss index_factory string")
-def vectorize(file, vector_index, model, factory):
+@click.option(
+    "--json-extract",
+    type=click.Choice(["auto", "all", "messages", "none"]),
+    default="auto",
+    help="How to extract text from JSON files",
+)
+def vectorize(file, vector_index, model, factory, json_extract):
     """Embed a file into the vector index."""
     from .vector_embedder import embed_file
 
-    embed_file(file, vector_index, model, factory=factory)
+    embed_file(file, vector_index, model, factory=factory, json_extract=json_extract)
     click.echo(f"\u2713 Embedded {file} into {vector_index}")
 
 @cli.command()

--- a/ai_memory/ingest/zip_watcher.py
+++ b/ai_memory/ingest/zip_watcher.py
@@ -24,7 +24,10 @@ def process_zip(zip_path: Path, dest_root: Path, index: str | None, model: str |
     for mem_file in dest_dir.rglob("*memory.json"):
         subprocess.run(["aimem", "import", str(mem_file)], check=True)
 
-    for log_file in list(dest_dir.rglob("*.md")) + [p for p in dest_dir.rglob("*.json") if not p.name.endswith("memory.json")]:
+    text_logs = list(dest_dir.rglob("*.md"))
+    json_logs = [p for p in dest_dir.rglob("*.json") if not p.name.endswith("memory.json")]
+
+    for log_file in text_logs + json_logs:
         cmd = [
             sys.executable,
             "-m",
@@ -38,6 +41,8 @@ def process_zip(zip_path: Path, dest_root: Path, index: str | None, model: str |
             "--model",
             model,
         ]
+        if log_file.suffix == ".json":
+            cmd += ["--json-extract", "messages"]
         subprocess.run([c for c in cmd if c], check=True)
 
 

--- a/ai_memory/vector_embedder.py
+++ b/ai_memory/vector_embedder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import logging
 import os
+import json
 
 import numpy as np
 import faiss
@@ -10,14 +11,23 @@ import faiss
 logger = logging.getLogger(__name__)
 
 
-_DIMS = 1
+_DIMS = 512
+
+
+def _embed_text(text: str) -> np.ndarray:
+    """Return an embedding for the given text."""
+    length = float(len(text.encode("utf-8")))
+    vec = np.full((_DIMS,), length, dtype="float32")
+    vec = vec.reshape(1, -1)
+    faiss.normalize_L2(vec)
+    return vec
 
 
 def _embed(file: str) -> np.ndarray:
     """Return a trivial embedding for the given file."""
     with open(file, "rb") as f:
         length = len(f.read())
-    vec = np.array([[float(length)]], dtype="float32")
+    vec = np.full((_DIMS,), float(length), dtype="float32").reshape(1, -1)
     faiss.normalize_L2(vec)
     return vec
 
@@ -26,6 +36,59 @@ def _create_index(factory: str | None) -> faiss.Index:
     if factory:
         return faiss.index_factory(_DIMS, factory)
     return faiss.IndexFlatIP(_DIMS)
+
+
+def _extract_strings(obj, max_size=2048):
+    strings: list[str] = []
+    if isinstance(obj, dict):
+        for v in obj.values():
+            strings.extend(_extract_strings(v, max_size))
+    elif isinstance(obj, list):
+        for item in obj:
+            strings.extend(_extract_strings(item, max_size))
+    elif isinstance(obj, str):
+        if len(obj.encode("utf-8")) < max_size:
+            strings.append(obj)
+    return strings
+
+
+def _extract_messages(obj) -> list[str]:
+    messages = []
+    if not isinstance(obj, dict):
+        return messages
+    convs = obj.get("conversations")
+    if isinstance(convs, list):
+        for conv in convs:
+            msgs = conv.get("messages") if isinstance(conv, dict) else None
+            if isinstance(msgs, list):
+                for m in msgs:
+                    if isinstance(m, dict):
+                        content = m.get("content")
+                        if isinstance(content, str) and len(content.encode("utf-8")) < 2048:
+                            messages.append(content)
+    return messages
+
+
+def _json_to_text(path: str, mode: str) -> str | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.warning("JSON parse error for %s: %s", path, e)
+        return None
+    if not isinstance(data, (dict, list)):
+        return None
+    if mode == "messages":
+        texts = _extract_messages(data)
+    elif mode == "all":
+        texts = _extract_strings(data)
+    elif mode == "auto":
+        texts = _extract_messages(data)
+        if not texts:
+            texts = _extract_strings(data)
+    else:
+        return None
+    return "\n\n".join(texts)
 
 
 def _load_index(path: Path, factory: str | None) -> faiss.Index:
@@ -45,22 +108,40 @@ def _load_index(path: Path, factory: str | None) -> faiss.Index:
         raise
 
 
-def embed_file(file: str, index_path: str, model: str, factory: str | None = None) -> None:
+def embed_file(
+    file: str,
+    index_path: str,
+    model: str,
+    factory: str | None = None,
+    json_extract: str = "auto",
+) -> None:
     """Embed a file into a FAISS index."""
     index_file = Path(index_path)
     index_file.parent.mkdir(parents=True, exist_ok=True)
     index = _load_index(index_file, factory)
-    vec = _embed(file)
+    vec = None
+    if file.endswith(".json"):
+        text = _json_to_text(file, json_extract)
+        if text:
+            vec = _embed_text(text)
+    if vec is None:
+        vec = _embed(file)
     if not index.is_trained and hasattr(index, "train"):
         index.train(vec)
     index.add(vec)
     faiss.write_index(index, str(index_file))
 
 
-def recall(file: str, index_path: str) -> float:
+def recall(file: str, index_path: str, json_extract: str = "auto") -> float:
     """Return similarity score for the file against the index."""
     index = faiss.read_index(str(index_path))
-    vec = _embed(file)
+    vec = None
+    if file.endswith(".json"):
+        text = _json_to_text(file, json_extract)
+        if text:
+            vec = _embed_text(text)
+    if vec is None:
+        vec = _embed(file)
     D, _ = index.search(vec, 1)
     score = float(D[0][0])
     if index.metric_type == faiss.METRIC_L2:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ai-memory",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(include=["ai_memory", "ai_memory.*"]),
     install_requires=[
         "click>=8.0.0",

--- a/tests/test_vectorize_json.py
+++ b/tests/test_vectorize_json.py
@@ -1,0 +1,20 @@
+import json
+import faiss
+from ai_memory.vector_embedder import embed_file
+
+
+def test_vectorize_json_messages(tmp_path):
+    data = {
+        "conversations": [
+            {"messages": [{"content": "hello"}, {"content": "world"}]}
+        ]
+    }
+    json_file = tmp_path / "conversations.json"
+    json_file.write_text(json.dumps(data))
+    index = tmp_path / "vec.faiss"
+
+    embed_file(str(json_file), str(index), "dummy", factory="Flat", json_extract="messages")
+
+    idx = faiss.read_index(str(index))
+    assert idx.ntotal > 0
+    assert index.stat().st_size > 1024


### PR DESCRIPTION
## Summary
- support JSON parsing in vector_embedder with `json_extract` modes
- expose `--json-extract` flag in CLI
- embed JSON conversations in ingest zip watcher
- add regression test for JSON vectorizing
- bump version to 0.1.1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688135390ca08332893b7e21f2290f97