### PR TITLE
Fix ChatGPT JSON vectorization command

### DIFF
--- a/ai_memory/ingest/zip_watcher.py
+++ b/ai_memory/ingest/zip_watcher.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 import zipfile
 
@@ -29,9 +28,7 @@ def process_zip(zip_path: Path, dest_root: Path, index: str | None, model: str |
 
     for log_file in text_logs + json_logs:
         cmd = [
-            sys.executable,
-            "-m",
-            "ai_memory.cli",
+            "aimem",
             "vectorize",
             str(log_file),
             "--vector-index",


### PR DESCRIPTION
## Summary
- call `aimem vectorize` directly when ingesting logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881429cd8d08332ae88bdbbf293a513