### PR TITLE
Add ChatGPT extractor and CPU-only mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Force CPU mode to avoid kernel panics
+export CUDA_VISIBLE_DEVICES=""
+export LUNA_VECTOR_DIR="$HOME/aimemorysystem"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 ai_memory.egg-info/
 .ai_memory/
+# Large data files
 *.pkl
+*.index
+*.faiss
+/aimemorysystem/
+/backup/

--- a/bin/luna-cpu
+++ b/bin/luna-cpu
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+import os
+os.environ['CUDA_VISIBLE_DEVICES'] = ''  # Force CPU before any imports
+os.environ['PYTORCH_CUDA_ALLOC_CONF'] = ''
+import sys
+from ai_memory.luna_wrapper import main
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/extract_chatgpt_messages.py
+++ b/tools/extract_chatgpt_messages.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Extract and vectorize messages from ChatGPT conversation exports."""
+import json
+import sys
+import subprocess
+from pathlib import Path
+from typing import List, Dict, Any
+import tempfile
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def extract_messages_from_chatgpt(file_path: Path) -> List[str]:
+    """Extract actual message content from ChatGPT export format."""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    messages: List[str] = []
+    conversations = data if isinstance(data, list) else [data]
+
+    for conv in conversations:
+        if 'mapping' not in conv:
+            continue
+
+        title = conv.get('title', 'Untitled')
+        mapping = conv['mapping']
+        for node_id, node in mapping.items():
+            if not node or not isinstance(node, dict):
+                continue
+            message = node.get('message')
+            if not message or not isinstance(message, dict):
+                continue
+            content = message.get('content', {})
+            if not isinstance(content, dict):
+                continue
+            parts = content.get('parts', [])
+            if not parts:
+                continue
+
+            text_parts: List[str] = []
+            for part in parts:
+                if isinstance(part, str) and part.strip():
+                    text_parts.append(part)
+
+            if not text_parts:
+                continue
+
+            text = ' '.join(text_parts)
+            if len(text) < 20 or text == '...':
+                continue
+
+            author = message.get('author', {})
+            role = author.get('role', 'unknown') if isinstance(author, dict) else 'unknown'
+            full_text = f"[{title}] {role}: {text}"
+            messages.append(full_text)
+
+    return messages
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: extract_chatgpt_messages.py <conversations.json>")
+        sys.exit(1)
+
+    file_path = Path(sys.argv[1])
+    if not file_path.exists():
+        logger.error("File not found: %s", file_path)
+        sys.exit(1)
+
+    logger.info("Processing %s...", file_path)
+
+    try:
+        messages = extract_messages_from_chatgpt(file_path)
+        logger.info("Extracted %d messages", len(messages))
+        if not messages:
+            logger.warning("No messages found!")
+            return
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(messages, f, ensure_ascii=False, indent=2)
+            temp_file = f.name
+
+        vector_dir = Path(os.getenv('LUNA_VECTOR_DIR', Path.home() / 'aimemorysystem'))
+        vector_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            'aimem', 'vectorize', temp_file,
+            '--json-extract', 'all',
+            '--vector-index', str(vector_dir / 'memory_store.index'),
+            '--model', 'llama3:70b-instruct-q4_K_M'
+        ]
+
+        env = os.environ.copy()
+        env['CUDA_VISIBLE_DEVICES'] = ''
+
+        logger.info('Vectorizing %d messages...', len(messages))
+        result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+        if result.returncode != 0:
+            logger.error('Vectorization failed: %s', result.stderr)
+            sys.exit(1)
+
+        logger.info('Successfully vectorized messages')
+    except json.JSONDecodeError as e:
+        logger.error('Invalid JSON in %s: %s', file_path, e)
+        sys.exit(1)
+    except Exception as e:
+        logger.error('Error processing %s: %s', file_path, e)
+        sys.exit(1)
+    finally:
+        if 'temp_file' in locals():
+            Path(temp_file).unlink(missing_ok=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/process_all_conversations.sh
+++ b/tools/process_all_conversations.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Process all ChatGPT conversation exports with CPU mode
+
+set -e
+cd "$(dirname "$0")/.."
+
+export CUDA_VISIBLE_DEVICES=""
+export LUNA_VECTOR_DIR="$HOME/aimemorysystem"
+
+# Backup existing data
+if [ -d "$LUNA_VECTOR_DIR" ]; then
+    echo "Backing up existing vector store..."
+    backup_dir="$LUNA_VECTOR_DIR/backup_$(date +%Y%m%d_%H%M%S)"
+    mkdir -p "$backup_dir"
+    cp "$LUNA_VECTOR_DIR"/memory_store.* "$backup_dir/" 2>/dev/null || true
+fi
+
+# Clean start
+echo "Starting fresh..."
+rm -f "$LUNA_VECTOR_DIR"/memory_store.*
+
+# Process each conversations.json file
+echo "Processing ChatGPT conversations..."
+find ~/chatlogs -name "conversations.json" -type f | while read -r file; do
+    echo "Processing: $file"
+    python tools/extract_chatgpt_messages.py "$file"
+    sleep 0.5
+done
+
+# Check results
+echo -e "\nChecking results..."
+python - <<'PY'
+import faiss, pickle, os
+vec_dir = os.getenv('LUNA_VECTOR_DIR', os.path.expanduser('~/aimemorysystem'))
+idx_path = os.path.join(vec_dir, 'memory_store.index')
+pkl_path = os.path.join(vec_dir, 'memory_store.pkl')
+try:
+    idx = faiss.read_index(idx_path)
+    print(f'Total vectors: {idx.ntotal}')
+    with open(pkl_path, 'rb') as f:
+        meta = pickle.load(f)
+    print(f'Metadata entries: {len(meta)}')
+    if meta:
+        entries = list(meta.values()) if isinstance(meta, dict) else meta
+        print('\nFirst 3 entries:')
+        for i, entry in enumerate(entries[:3], 1):
+            text = entry.get('text', '') if isinstance(entry, dict) else str(entry)
+            print(f"{i}. {text[:100]}...")
+except Exception as e:
+    print(f'Error: {e}')
+PY
+
+echo -e "\nDone! Test with: luna-cpu \"What have we discussed about memory systems?\""


### PR DESCRIPTION
## Summary
- support CPU-only usage via `luna-cpu`
- add extractor for ChatGPT export format
- add batch processing script for conversation logs
- provide CPU fallback when loading embedding model
- ignore large vector store files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881c34e42f8833283997d08785fa9e5