### PR TITLE
Stub SentenceTransformer for offline CI

### DIFF
--- a/ai_memory/testing/_stubs.py
+++ b/ai_memory/testing/_stubs.py
@@ -1,0 +1,19 @@
+import hashlib
+import numpy as np
+
+class FakeSentenceTransformer:
+    """Simple fake SentenceTransformer for offline tests."""
+
+    def __init__(self, *args, **kwargs):
+        self.dim = 1024
+
+    def _vec(self, text: str) -> np.ndarray:
+        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % (2**32)
+        rng = np.random.default_rng(seed)
+        return rng.random(self.dim, dtype=np.float32)
+
+    def encode(self, sentences, convert_to_numpy=True, **kwargs):
+        if isinstance(sentences, str):
+            sentences = [sentences]
+        vecs = np.vstack([self._vec(s) for s in sentences])
+        return vecs

--- a/ai_memory/vector_embedder.py
+++ b/ai_memory/vector_embedder.py
@@ -42,7 +42,10 @@ def _get_model():
                 pass
         if SentenceTransformer is None:
             raise RuntimeError("sentence-transformers is not installed")
-        _model = SentenceTransformer(_model_name, device=device)
+        kwargs = {}
+        if os.getenv("HF_HUB_OFFLINE") or os.getenv("LUNA_OFFLINE_TEST"):
+            kwargs["local_files_only"] = True
+        _model = SentenceTransformer(_model_name, device=device, **kwargs)
     return _model
 
 

--- a/tests/test_chat_with_luna.py
+++ b/tests/test_chat_with_luna.py
@@ -8,8 +8,11 @@ No network or Ollama required.
 import json
 import urllib.request
 import subprocess
+import os
 from ai_memory import chat_with_luna
 
+
+os.environ.setdefault("LUNA_OFFLINE_TEST", "1")
 
 def _fake_run(cmd, check, capture_output, text):
     class _R:  # minimal CompletedProcess

--- a/tests/test_vector_embedder.py
+++ b/tests/test_vector_embedder.py
@@ -1,5 +1,16 @@
 import os
+import sys
+import types
+import pytest
+from ai_memory.testing._stubs import FakeSentenceTransformer
 from ai_memory.vector_embedder import embed_file, recall
+
+
+@pytest.fixture(autouse=True)
+def _stub_transformer(monkeypatch):
+    fake_mod = types.SimpleNamespace(SentenceTransformer=FakeSentenceTransformer)
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+    monkeypatch.setattr(embed_file.__module__ + ".SentenceTransformer", FakeSentenceTransformer, raising=False)
 
 
 def test_self_heal(tmp_path):


### PR DESCRIPTION
## Summary
- add `FakeSentenceTransformer` stub for offline tests
- monkeypatch SentenceTransformer in `test_vector_embedder`
- set `LUNA_OFFLINE_TEST` flag in chat-with-luna tests
- respect `HF_HUB_OFFLINE` or `LUNA_OFFLINE_TEST` in `vector_embedder`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688549090ad08332b5696e94586ed2cb