### PR TITLE
Implement memory summarisation and vacuum command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Import a structured JSON log into the memory database:
 aimem import ./chatlogs/claude_memory.json
 ```
 
+To compact old memories into a summary, run:
+
+```bash
+aimem vacuum
+```
+
 Embed a chat log into a vector index. For ChatGPT exports use
 `--json-extract messages` so only the conversation text is embedded:
 

--- a/ai_memory/cli.py
+++ b/ai_memory/cli.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 import click
 
+from .memory_updater import MemoryUpdater
+
 from .memory_store import MemoryStore
 from .database import MemoryDatabase
 from .model_config import get_model_budget
@@ -231,6 +233,19 @@ def convert_metadata(pkl_file, output):
     click.echo(f"✓ Converted {count} entries to {output_path}")
 
 
+@cli.command()
+def vacuum():
+    """Force compaction of the memory store."""
+    try:
+        store = MemoryStore()
+        updater = MemoryUpdater(store)
+        updater._compress_old_memories()
+        click.echo("✓ Memory vacuum complete")
+    except Exception as e:
+        click.echo(f"✗ Vacuum failed: {e}", err=True)
+        sys.exit(1)
+
+
 @cli.command(name="debug-index")
 @click.option("--vector-index", help="Path to vector index")
 def debug_index(vector_index):
@@ -268,3 +283,4 @@ def debug_index(vector_index):
 
 if __name__ == "__main__":
     cli()
+

--- a/ai_memory/compression.py
+++ b/ai_memory/compression.py
@@ -1,17 +1,57 @@
+from __future__ import annotations
+
+import re
+
+from .token_counter import TokenCounter
+
+
 class MemoryCompressor:
-    def __init__(self):
-        pass
+    """Stateless helpers to shrink memory fragments."""
 
-    def _compress_code(self, code: str) -> str:
-        # naive code compression: remove empty lines
-        lines = [
-            l
-            for l in code.splitlines()
-            if l.strip() and not l.strip().startswith("#")
-        ]
-        return " ".join(lines)
+    def __init__(self) -> None:
+        self.counter = TokenCounter()
 
-    def _compress_conversation(self, text: str) -> str:
-        # placeholder summarization
-        sentences = text.split(".")
-        return ". ".join(sentences[:2])
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _trim(self, text: str) -> str:
+        tokens = text.split()
+        if len(tokens) <= 120:
+            return " ".join(tokens)
+        return " ".join(tokens[:120])
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def compress_code(self, code: str) -> str:
+        """Return code with comments/blank lines removed and whitespace normalised."""
+        lines: list[str] = []
+        for line in code.splitlines():
+            # strip inline comments
+            line = re.sub(r"#.*", "", line).strip()
+            if not line:
+                continue
+            lines.append(line)
+        result = " ".join(lines)
+        return self._trim(result)
+
+    def compress_text(self, text: str) -> str:
+        """Summarise text using a simple frequency based heuristic."""
+        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+        if not sentences:
+            return ""
+        # build word frequencies
+        freq: dict[str, int] = {}
+        for sent in sentences:
+            for tok in re.findall(r"\b\w+\b", sent.lower()):
+                freq[tok] = freq.get(tok, 0) + 1
+
+        scored: list[tuple[int, str]] = []
+        for sent in sentences:
+            score = sum(freq.get(tok, 0) for tok in re.findall(r"\b\w+\b", sent.lower()))
+            scored.append((score, sent))
+
+        top_sentences = [s for _, s in sorted(scored, key=lambda x: x[0], reverse=True)[:3]]
+        result = " ".join(top_sentences)
+        return self._trim(result)
+

--- a/ai_memory/conversation_session.py
+++ b/ai_memory/conversation_session.py
@@ -1,5 +1,7 @@
 import time
 from .memory_optimizer import MemoryOptimizer
+from .memory_updater import MemoryUpdater
+from datetime import datetime, timezone
 
 
 class ConversationSession:
@@ -8,6 +10,25 @@ class ConversationSession:
         self.start_ts = time.time()
         self.title = "session"
         self.optimizer = MemoryOptimizer()
+        self.updater = MemoryUpdater(self.optimizer.memory_store)
+
+    def add_exchange(self, user_msg: str, assistant_msg: str) -> None:
+        """Record a chat exchange and trigger maintenance."""
+        cur = self.optimizer.memory_store.conn.cursor()
+        ts = datetime.now(tz=timezone.utc).isoformat()
+        if self.session_id:
+            cur.execute(
+                "INSERT OR IGNORE INTO conversations (conv_id, user_id, title, started_at, updated_at) VALUES (?,?,?,?,?)",
+                (self.session_id, "default", self.title, ts, ts),
+            )
+            cur.execute(
+                "UPDATE conversations SET updated_at=? WHERE conv_id=?",
+                (ts, self.session_id),
+            )
+        self.optimizer.memory_store.add(user_msg, conv_id=self.session_id)
+        self.optimizer.memory_store.add(assistant_msg, conv_id=self.session_id)
+        log = f"{user_msg}\n{assistant_msg}"
+        self.updater.post_conversation_update(log)
 
     def build_context(self, query: str, model: str = "gpt-4", limit: int | None = None) -> str:
         max_tokens = limit if limit is not None else 4096
@@ -16,3 +37,4 @@ class ConversationSession:
             current_task=query,
             conversation_id=self.session_id,
         )
+

--- a/ai_memory/memory_updater.py
+++ b/ai_memory/memory_updater.py
@@ -1,27 +1,59 @@
+from __future__ import annotations
+
 from typing import List
 
 from .memory_store import MemoryStore
+from .compression import MemoryCompressor
 
 
 class MemoryUpdater:
-    def __init__(self, store: MemoryStore, max_size: int = 1000):
+    """Maintain size of the memory table with lightweight summarisation."""
+
+    def __init__(self, store: MemoryStore, max_size: int = 1000) -> None:
         self.memory_store = store
         self.max_size = max_size
+        self.compressor = MemoryCompressor()
 
     def post_conversation_update(self, conversation_log: str) -> None:
-        # placeholder implementation
+        """Entry point after a conversation exchange."""
         self.update_access_counts(conversation_log)
         if len(self.memory_store.get_all()) > self.max_size:
-            self.compress_old_memories()
+            self._compress_old_memories()
 
+    # ------------------------------------------------------------------
+    # stubs for future entity/solution extraction
+    # ------------------------------------------------------------------
     def extract_entities(self, log: str) -> List[str]:
         return []
 
     def extract_solutions(self, log: str) -> List[str]:
         return []
 
-    def update_access_counts(self, log: str) -> None:
+    def update_access_counts(self, log: str) -> None:  # pragma: no cover - stub
         pass
 
-    def compress_old_memories(self) -> None:
-        pass
+    # ------------------------------------------------------------------
+    # compaction logic
+    # ------------------------------------------------------------------
+    def _compress_old_memories(self) -> None:
+        """Summarise and delete the least important memories."""
+        memories = self.memory_store.get_all()
+        if len(memories) <= self.max_size:
+            return
+
+        sorted_mems = sorted(
+            memories.values(), key=lambda m: (m.importance_weight, m.timestamp)
+        )
+        k = len(memories) - self.max_size + 1
+        to_summarise = sorted_mems[:k]
+
+        combined = "\n".join(m.content for m in to_summarise)
+        summary = self.compressor.compress_text(combined)
+
+        cur = self.memory_store.conn.cursor()
+        for mem in to_summarise:
+            cur.execute("DELETE FROM memory_fragments WHERE mem_id=?", (mem.memory_id,))
+        self.memory_store.conn.commit()
+
+        self.memory_store.add(summary, importance=0.8, source_type="summary")
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: slow running tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import subprocess, json, os, sys, tempfile, time
+import pytest
 
 
 def _run(cmd, env=None):
@@ -94,6 +95,7 @@ def test_console_script_import(tmp_path):
     assert count == 2
 
 
+@pytest.mark.slow
 def test_vectorize(tmp_path):
     txt = tmp_path / "sample.txt"
     txt.write_text("hello")

--- a/tests/test_cli_vacuum.py
+++ b/tests/test_cli_vacuum.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+
+
+def _run(cmd, env=None):
+    result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_cli_vacuum(tmp_path, monkeypatch):
+    monkeypatch.setenv("AI_MEMORY_ROOT", str(tmp_path / "ai_memory"))
+    import importlib
+    import ai_memory.memory_db as db
+    import ai_memory.memory_store as ms
+    importlib.reload(db)
+    importlib.reload(ms)
+    env = os.environ.copy()
+    MemoryStore = ms.MemoryStore
+    store = MemoryStore()
+    for i in range(1100):
+        store.add(f"m{i}")
+    store.conn.close()
+
+    out = _run("python -m ai_memory.cli vacuum", env=env)
+    assert "Memory vacuum" in out
+
+    store = MemoryStore()
+    assert len(store.get_all()) <= 1000
+    store.conn.close()
+

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,27 @@
+import re
+from ai_memory.compression import MemoryCompressor
+from ai_memory.token_counter import TokenCounter
+
+
+def test_code_comments_removed():
+    comp = MemoryCompressor()
+    code = """
+    def foo(): # inline comment
+        pass  # TODO something
+
+    # standalone comment
+    print(foo())
+    """
+    out = comp.compress_code(code)
+    assert "#" not in out
+    assert "foo()" in out
+    assert "pass" in out
+
+
+def test_conversation_trimmed():
+    comp = MemoryCompressor()
+    long_text = " ".join([f"sentence{i}." for i in range(200)])
+    out = comp.compress_text(long_text)
+    tk = TokenCounter()
+    assert tk.count(out) <= 120
+

--- a/tests/test_luna_integration.py
+++ b/tests/test_luna_integration.py
@@ -1,6 +1,9 @@
 import os
 import subprocess
 from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.slow
 
 
 def test_luna_loads_memories(tmp_path):

--- a/tests/test_memory_updater.py
+++ b/tests/test_memory_updater.py
@@ -1,0 +1,21 @@
+import sqlite3
+from ai_memory.memory_db import _ensure_schema
+from ai_memory.memory_store import MemoryStore
+from ai_memory.memory_updater import MemoryUpdater
+
+
+def test_auto_summarisation():
+    conn = sqlite3.connect(":memory:")
+    _ensure_schema(conn)
+    store = MemoryStore(conn)
+
+    for i in range(1200):
+        store.add(f"mem {i}", importance=0.1)
+
+    updater = MemoryUpdater(store, max_size=1000)
+    updater.post_conversation_update("user and assistant")
+
+    all_mem = store.get_all()
+    assert len(all_mem) == 1000
+    assert any(m.type == "summary" for m in all_mem.values())
+

--- a/tests/test_session_updater.py
+++ b/tests/test_session_updater.py
@@ -1,0 +1,17 @@
+import importlib
+import os
+import ai_memory.conversation_session as cs
+
+
+def test_session_updater_runs(tmp_path, monkeypatch):
+    monkeypatch.setenv("AI_MEMORY_ROOT", str(tmp_path / "ai_memory"))
+    importlib.reload(cs)
+    session = cs.ConversationSession()
+    session.session_id = "sess"
+    for i in range(1100):
+        session.add_exchange(f"u{i}", f"a{i}")
+    all_mem = session.optimizer.memory_store.get_all()
+    assert len(all_mem) <= 1000
+    assert any(m.type == "summary" for m in all_mem.values())
+
+

--- a/tests/test_vector_compatibility.py
+++ b/tests/test_vector_compatibility.py
@@ -2,6 +2,9 @@ import os
 import subprocess
 import json
 import pickle
+import pytest
+
+pytestmark = pytest.mark.slow
 
 from ai_memory.vector_memory import VectorMemory
 

--- a/tests/test_vector_embedder.py
+++ b/tests/test_vector_embedder.py
@@ -2,6 +2,8 @@ import os
 import sys
 import types
 import pytest
+
+pytestmark = pytest.mark.slow
 from ai_memory.testing._stubs import FakeSentenceTransformer
 from ai_memory.vector_embedder import embed_file, recall
 

--- a/tests/test_vectorize_json.py
+++ b/tests/test_vectorize_json.py
@@ -3,6 +3,9 @@ import pickle
 import subprocess
 from pathlib import Path
 import faiss
+import pytest
+
+pytestmark = pytest.mark.slow
 
 
 def test_vectorize_json_auto(tmp_path):


### PR DESCRIPTION
## Summary
- implement `MemoryCompressor` for code and text
- auto-summarise old memories via `MemoryUpdater`
- hook updater into `ConversationSession`
- add `aimem vacuum` CLI command
- mark FAISS-heavy tests as `@pytest.mark.slow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888134fbd3c8332878f4ef1d56ebca1