### PR TITLE
Lazy-load VectorMemory import

### DIFF
--- a/ai_memory/__init__.py
+++ b/ai_memory/__init__.py
@@ -1,3 +1,23 @@
-from .vector_memory import VectorMemory
+"""ai_memory package exposing VectorMemory lazily."""
 
 __all__ = ["VectorMemory"]
+
+
+class _VectorMemoryProxy:
+    def __call__(self, *args, **kwargs):
+        from .vector_memory import VectorMemory
+        return VectorMemory(*args, **kwargs)
+
+    def __getattr__(self, attr):
+        from .vector_memory import VectorMemory
+        return getattr(VectorMemory, attr)
+
+
+_proxy = _VectorMemoryProxy()
+
+
+def __getattr__(name):
+    if name == "VectorMemory":
+        return _proxy
+    raise AttributeError(name)
+

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+def test_init_without_faiss():
+    code = "\n".join([
+        "import builtins, sys",
+        "orig = builtins.__import__",
+        "def fake(name, *a, **k):",
+        "    if name == 'faiss': raise ImportError('no faiss')",
+        "    return orig(name, *a, **k)",
+        "builtins.__import__ = fake",
+        "import ai_memory, sys",
+        "print(hasattr(ai_memory, 'VectorMemory'))",
+    ])
+    res = subprocess.run([sys.executable, '-c', code], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == 'True'


### PR DESCRIPTION
## Summary
- avoid importing faiss on ai_memory import by lazily exposing `VectorMemory`
- add regression test ensuring import works without faiss installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d43d0de48332bf305a23b9321abf