### PR TITLE
Honor AIMEM_DISABLE_TORCH + restore alias

### DIFF
--- a/ai_memory/__main__.py
+++ b/ai_memory/__main__.py
@@ -1,0 +1,4 @@
+from ai_memory.luna_wrapper import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ai_memory/luna_wrapper.py
+++ b/ai_memory/luna_wrapper.py
@@ -8,6 +8,17 @@ import logging
 import os
 from datetime import datetime
 
+import os, types, sys
+if os.getenv('AIMEM_DISABLE_TORCH', '').lower() in {'1', 'true'}:
+    from ai_memory.testing._stubs import FakeSentenceTransformer as SentenceTransformer
+    # Ensure any later 'import sentence_transformers' gets the stub
+    sys.modules.setdefault(
+        'sentence_transformers',
+        types.SimpleNamespace(SentenceTransformer=SentenceTransformer)
+    )
+else:
+    from sentence_transformers import SentenceTransformer   # noqa
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -47,9 +58,14 @@ def main() -> int:
     from ai_memory.vector_memory import VectorMemory
 
     try:
-        from sentence_transformers import SentenceTransformer
-        logger.info("Loading embedding model sentence-transformers/distiluse-base-multilingual-cased-v2 on %s", device)
-        model = SentenceTransformer("sentence-transformers/distiluse-base-multilingual-cased-v2", device=device)
+        logger.info(
+            "Loading embedding model sentence-transformers/distiluse-base-multilingual-cased-v2 on %s",
+            device,
+        )
+        model = SentenceTransformer(
+            "sentence-transformers/distiluse-base-multilingual-cased-v2",
+            device=device,
+        )
     except Exception:  # ImportError or runtime failure
         logger.warning("sentence_transformers not available, using mock embeddings")
         model = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[options.entry_points]
+console_scripts =
+    luna = ai_memory.__main__:main
+    luna-cpu = ai_memory.__main__:main


### PR DESCRIPTION
## Summary
- allow disabling torch in `luna_wrapper` by stubbing `SentenceTransformer`
- add `ai_memory.__main__` module
- provide `luna` and `luna-cpu` entrypoints in `setup.cfg`

## Testing
- `export AIMEM_DISABLE_TORCH=1`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7a8d06408332bc332b39f4bb0613