### PR TITLE
Add stdin-friendly luna CLI

### DIFF
--- a/ai_memory/chat_with_luna.py
+++ b/ai_memory/chat_with_luna.py
@@ -3,6 +3,11 @@
 Usage (once installed):
     chat-with-luna "Why did we choose FAISS?"
 
+This CLI now mirrors the convenience of ``luna`` from ``memory_optimizer``:
+
+* Anything after ``--`` is treated verbatim as the prompt
+* ``-`` reads the prompt from ``stdin``
+
 Environment variables respected:
     OLLAMA_MODEL     – model name in Ollama (default: "luna")
     LUNA_VECTOR_DIR  – where the vector index + metadata live
@@ -16,6 +21,16 @@ import sys
 import json
 import urllib.request
 from typing import Optional
+
+
+def _clean_prompt(tokens: list[str]) -> str:
+    """Join tokens and gently strip matching outer quotes."""
+    if not tokens:
+        return ""
+    prompt = " ".join(tokens)
+    if len(prompt) >= 2 and prompt[0] == prompt[-1] and prompt[0] in {"'", '"'}:
+        prompt = prompt[1:-1]
+    return prompt
 
 
 # ------------------------------------------------------------------- #
@@ -83,29 +98,38 @@ def _query_ollama(model: str, prompt: str) -> str:
 
 def main(argv: Optional[list[str]] = None) -> int:
     import argparse
+
     ap = argparse.ArgumentParser(
-        description="Ask Luna with automatic memory context"
+        prog="chat-with-luna",
+        description="Ask Luna with automatic memory context",
+        add_help=False,
     )
-    ap.add_argument(
-        "query",
-        help="Your question – enclose in quotes if it contains spaces.",
-    )
-    ap.add_argument(
-        "--context-model", "-c",
-        help="Model profile to tell memory_optimizer (e.g. gpt-4-32k, luna).",
-    )
+    ap.add_argument("prompt", nargs=argparse.REMAINDER,
+                    help="Prompt text (use '-' to read stdin)")
+    ap.add_argument("--context-model", "-c",
+                    help="Model profile to tell memory_optimizer (e.g. gpt-4-32k, luna).")
+    ap.add_argument("-h", "--help", action="help", help="Show this help and exit")
     ns = ap.parse_args(argv)
 
+    if ns.prompt == ["-"] or not ns.prompt:
+        query = sys.stdin.read().rstrip("\n")
+    else:
+        query = _clean_prompt(ns.prompt)
+
+    if not query:
+        print("\u274c  No prompt provided (use '-' to read stdin).", file=sys.stderr)
+        return 1
+
     # Step 1 – gather context
-    ctx = _fetch_memory_context(ns.query, ns.context_model)
+    ctx = _fetch_memory_context(query, ns.context_model)
     # Step 2 – build prompt
-    prompt = _build_prompt(ctx, ns.query)
+    prompt = _build_prompt(ctx, query)
     # Step 3 – send to Luna
     model_name = os.getenv("OLLAMA_MODEL", "luna")
     try:
         answer = _query_ollama(model_name, prompt)
     except Exception as exc:
-        print(f"[✗] Failed to reach Ollama: {exc}", file=sys.stderr)
+        print(f"[\u2717] Failed to reach Ollama: {exc}", file=sys.stderr)
         return 1
     print(answer)
     return 0

--- a/tests/test_chat_with_luna.py
+++ b/tests/test_chat_with_luna.py
@@ -9,6 +9,7 @@ import json
 import urllib.request
 import subprocess
 import os
+import io
 from ai_memory import chat_with_luna
 
 
@@ -40,4 +41,12 @@ def test_cli_monkeypatch(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _fake_run)
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
     rc = chat_with_luna.main(["hello"])
+    assert rc == 0
+
+
+def test_cli_stdin(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr("sys.stdin", io.StringIO("stdin query"))
+    rc = chat_with_luna.main(["-"])
     assert rc == 0


### PR DESCRIPTION
## Summary
- improve `chat-with-luna` CLI: `-` reads stdin, `--` stops parsing
- keep memory context fetching and Ollama HTTP call
- test stdin handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b049e01b08332899afe2ad84958dc